### PR TITLE
Define STRICT_R_HEADERS in Makevars*, incldue cfloat for DBL_EPSILON

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,5 @@
 CXX_STD = CXX11
-PKG_CXXFLAGS += -DRCPP_PARALLEL_USE_TBB=1
+PKG_CXXFLAGS += -DRCPP_PARALLEL_USE_TBB=1 -DSTRICT_R_HEADERS
 PKG_LIBS += $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::RcppParallelLibs()")
 
 # use strip -S instead of strip --strip-debug for MacOS compatibility

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,4 @@
 CXX_STD = CXX11
-PKG_CXXFLAGS += -DRCPP_PARALLEL_USE_TBB=1
+PKG_CXXFLAGS += -DRCPP_PARALLEL_USE_TBB=1 -DSTRICT_R_HEADERS
 PKG_LIBS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" \
               -e "RcppParallel::RcppParallelLibs()")

--- a/src/mpx.cpp
+++ b/src/mpx.cpp
@@ -1,6 +1,7 @@
 #include "math.h" // math first to fix OSX error
 #include "mpx.h"
 #include "windowfunc.h"
+#include <cfloat> // DBL_EPSILON when STRICT_R_HEADERS
 
 // [[Rcpp::depends(RcppProgress)]]
 #include <progress.hpp>

--- a/src/scrimp.cpp
+++ b/src/scrimp.cpp
@@ -3,6 +3,7 @@
 #include "mass.h"
 #include "windowfunc.h"
 #include <numeric>
+#include <cfloat> // DBL_EPSILON when STRICT_R_HEADERS
 // [[Rcpp::depends(RcppProgress)]]
 #include <progress.hpp>
 // [[Rcpp::depends(RcppThread)]]

--- a/src/stamp.cpp
+++ b/src/stamp.cpp
@@ -2,6 +2,7 @@
 #include "stamp.h"
 #include "fft.h"
 #include "mass.h"
+#include <cfloat> // DBL_EPSILON when STRICT_R_HEADERS
 // [[Rcpp::depends(RcppProgress)]]
 #include <progress.hpp>
 // [[Rcpp::depends(RcppThread)]]

--- a/src/stomp.cpp
+++ b/src/stomp.cpp
@@ -2,6 +2,7 @@
 #include "stomp.h"
 #include "mass.h"
 #include <numeric>
+#include <cfloat> // DBL_EPSILON when STRICT_R_HEADERS
 // [[Rcpp::depends(RcppProgress)]]
 #include <progress.hpp>
 // [[Rcpp::depends(RcppThread)]]


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [code of conduct](https://github.com/wlandau/targets/blob/main/CODE_OF_CONDUCT.md) and the [contributing guidelines](https://github.com/wlandau/targets/blob/main/CONTRIBUTING.md).
* [x] I have already submitted an issue to the [issue tracker](https://github.com/matrix-profile-foundation/matrixprofiler/issues) to discuss my idea with the maintainer.   (You are pointing at the wrong issue trackcer here, I corrected the link)
* [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).

# Related GitHub issues and pull requests

* Ref: https://github.com/RcppCore/Rcpp/issues/1158

# Summary

Your CRAN package matrixprofiler uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at https://github.com/RcppCore/Rcpp/issues/1158 and the links therein for more context on this.

Here, instead of prefixing each #include <Rcpp.h> with STRICT_R_HEADERS we define it in src/Makevars* for a more minimal changeset (I think I personally prefer it in each file, but in your case the single joint header is very good too) . The actual change that is needed is the inclusion of cfloat (or float.h, C style) in four headers so that `DBL_EPSILON` is defined.

No other changes were made. The changes were first tested on the current CRAN sources which work.  However, in your github sources, while the _compilation_ still succeeds the _overall package ~build~ installation does not_ seemingly due to some non-standard use of `renv`.  I am hopeful you can sort this out at your end.  _Edit: This was arguably my fault for taking a shortcut of attempting to install directly from source. Building a tar.gz first and then testing the tar.gz works just fine._

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by https://github.com/RcppCore/Rcpp/issues/1158 to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.

(PS Your github issue template ponts to Will's issue tracker, not yours. That is probably not intentional. It also points to his CoC, people most often seem to point a local copy.)